### PR TITLE
Add /api/clear, remove HEAD support

### DIFF
--- a/api/ban.go
+++ b/api/ban.go
@@ -16,12 +16,9 @@ func HandleBan(w http.ResponseWriter, r *http.Request) {
 	var err string
 	var statusCode int
 
-	switch r.Method {
-	case http.MethodHead:
-		statusCode = http.StatusOK
-	case http.MethodPost:
+	if r.Method == http.MethodPost {
 		user, success, err, statusCode = handleBanImpl(w, r)
-	default:
+	} else {
 		err = "Incorrect request. POST or HEAD only."
 		statusCode = http.StatusBadRequest
 	}

--- a/api/clear.go
+++ b/api/clear.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"wwfc/database"
+)
+
+func HandleClear(w http.ResponseWriter, r *http.Request) {
+	var user *database.User
+	var success bool
+	var err string
+	var statusCode int
+
+	switch r.Method {
+	case http.MethodHead:
+		statusCode = http.StatusOK
+	case http.MethodPost:
+		user, success, err, statusCode = handleClearImpl(w, r)
+	default:
+		err = "Incorrect request. POST or HEAD only."
+		statusCode = http.StatusBadRequest
+	}
+
+	if user == nil {
+		user = &database.User{}
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+
+	if r.Method == http.MethodHead {
+		w.WriteHeader(statusCode)
+	} else {
+		json, _ := json.Marshal(UserActionResponse{*user, success, err})
+		w.Header().Set("Content-Length", strconv.Itoa(len(json)))
+		w.WriteHeader(statusCode)
+		w.Write(json)
+	}
+}
+
+type ClearRequestSpec struct {
+	Secret string
+	Pid    uint32
+}
+
+func handleClearImpl(w http.ResponseWriter, r *http.Request) (*database.User, bool, string, int) {
+	// TODO: Actual authentication rather than a fixed secret
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		return nil, false, "Unable to read request body", http.StatusBadRequest
+	}
+
+	var req ClearRequestSpec
+	err = json.Unmarshal(body, &req)
+	if err != nil {
+		return nil, false, err.Error(), http.StatusBadRequest
+	}
+
+	if apiSecret == "" || req.Secret != apiSecret {
+		return nil, false, "Invalid API secret in request", http.StatusUnauthorized
+	}
+
+	user, success := database.ClearProfile(pool, ctx, req.Pid)
+
+	if !success {
+		return nil, false, "Unable to query user data from the database", http.StatusInternalServerError
+	}
+
+	// Don't return empty JSON, this is placeholder for now.
+	return &user, true, "", http.StatusOK
+}

--- a/api/clear.go
+++ b/api/clear.go
@@ -14,13 +14,10 @@ func HandleClear(w http.ResponseWriter, r *http.Request) {
 	var err string
 	var statusCode int
 
-	switch r.Method {
-	case http.MethodHead:
-		statusCode = http.StatusOK
-	case http.MethodPost:
+	if r.Method == http.MethodPost {
 		user, success, err, statusCode = handleClearImpl(w, r)
-	default:
-		err = "Incorrect request. POST or HEAD only."
+	} else {
+		err = "Incorrect request. POST only."
 		statusCode = http.StatusBadRequest
 	}
 

--- a/api/kick.go
+++ b/api/kick.go
@@ -15,12 +15,9 @@ func HandleKick(w http.ResponseWriter, r *http.Request) {
 	var err string
 	var statusCode int
 
-	switch r.Method {
-	case http.MethodHead:
-		statusCode = http.StatusOK
-	case http.MethodPost:
+	if r.Method == http.MethodPost {
 		user, success, err, statusCode = handleKickImpl(w, r)
-	default:
+	} else {
 		err = "Incorrect request. POST or HEAD only."
 		statusCode = http.StatusBadRequest
 	}

--- a/api/motd.go
+++ b/api/motd.go
@@ -15,8 +15,6 @@ func HandleMotd(w http.ResponseWriter, r *http.Request) {
 	var statusCode int
 
 	switch r.Method {
-	case http.MethodHead:
-		statusCode = http.StatusOK
 	case http.MethodGet:
 		_motd, motdErr := gpcm.GetMessageOfTheDay()
 		if motdErr != nil {

--- a/api/unban.go
+++ b/api/unban.go
@@ -14,12 +14,9 @@ func HandleUnban(w http.ResponseWriter, r *http.Request) {
 	var err string
 	var statusCode int
 
-	switch r.Method {
-	case http.MethodHead:
-		statusCode = http.StatusOK
-	case http.MethodPost:
+	if r.Method == http.MethodPost {
 		user, success, err, statusCode = handleUnbanImpl(w, r)
-	default:
+	} else {
 		err = "Incorrect request. POST or HEAD only."
 		statusCode = http.StatusBadRequest
 	}

--- a/database/user.go
+++ b/database/user.go
@@ -17,6 +17,7 @@ const (
 	UpdateUserProfileID     = `UPDATE users SET profile_id = $3 WHERE user_id = $1 AND gsbrcd = $2`
 	UpdateUserNGDeviceID    = `UPDATE users SET ng_device_id = $2 WHERE profile_id = $1`
 	GetUser                 = `SELECT user_id, gsbrcd, email, unique_nick, firstname, lastname, open_host, last_ip_address, last_ingamesn FROM users WHERE profile_id = $1`
+	DeleteUser              = `DELETE FROM users WHERE profile_id = $1 RETURNING user_id, gsbrcd, email, unique_nick, firstname, lastname, open_host, last_ip_address, last_ingamesn`
 	DoesUserExist           = `SELECT EXISTS(SELECT 1 FROM users WHERE user_id = $1 AND gsbrcd = $2)`
 	IsProfileIDInUse        = `SELECT EXISTS(SELECT 1 FROM users WHERE profile_id = $1)`
 	DeleteUserSession       = `DELETE FROM sessions WHERE profile_id = $1`
@@ -142,6 +143,19 @@ func GetProfile(pool *pgxpool.Pool, ctx context.Context, profileId uint32) (User
 	user := User{}
 	row := pool.QueryRow(ctx, GetUser, profileId)
 	err := row.Scan(&user.UserId, &user.GsbrCode, &user.Email, &user.UniqueNick, &user.FirstName, &user.LastName, &user.OpenHost, &user.LastIPAddress, &user.LastInGameSn)
+	if err != nil {
+		return User{}, false
+	}
+
+	user.ProfileId = profileId
+	return user, true
+}
+
+func ClearProfile(pool *pgxpool.Pool, ctx context.Context, profileId uint32) (User, bool) {
+	user := User{}
+	row := pool.QueryRow(ctx, DeleteUser, profileId)
+	err := row.Scan(&user.UserId, &user.GsbrCode, &user.Email, &user.UniqueNick, &user.FirstName, &user.LastName, &user.OpenHost, &user.LastIPAddress, &user.LastInGameSn)
+
 	if err != nil {
 		return User{}, false
 	}

--- a/database/user.go
+++ b/database/user.go
@@ -17,7 +17,7 @@ const (
 	UpdateUserProfileID     = `UPDATE users SET profile_id = $3 WHERE user_id = $1 AND gsbrcd = $2`
 	UpdateUserNGDeviceID    = `UPDATE users SET ng_device_id = $2 WHERE profile_id = $1`
 	GetUser                 = `SELECT user_id, gsbrcd, email, unique_nick, firstname, lastname, open_host, last_ip_address, last_ingamesn FROM users WHERE profile_id = $1`
-	DeleteUser              = `DELETE FROM users WHERE profile_id = $1 RETURNING user_id, gsbrcd, email, unique_nick, firstname, lastname, open_host, last_ip_address, last_ingamesn`
+	ClearProfileQuery       = `DELETE FROM users WHERE profile_id = $1 RETURNING user_id, gsbrcd, email, unique_nick, firstname, lastname, open_host, last_ip_address, last_ingamesn`
 	DoesUserExist           = `SELECT EXISTS(SELECT 1 FROM users WHERE user_id = $1 AND gsbrcd = $2)`
 	IsProfileIDInUse        = `SELECT EXISTS(SELECT 1 FROM users WHERE profile_id = $1)`
 	DeleteUserSession       = `DELETE FROM sessions WHERE profile_id = $1`
@@ -153,7 +153,7 @@ func GetProfile(pool *pgxpool.Pool, ctx context.Context, profileId uint32) (User
 
 func ClearProfile(pool *pgxpool.Pool, ctx context.Context, profileId uint32) (User, bool) {
 	user := User{}
-	row := pool.QueryRow(ctx, DeleteUser, profileId)
+	row := pool.QueryRow(ctx, ClearProfileQuery, profileId)
 	err := row.Scan(&user.UserId, &user.GsbrCode, &user.Email, &user.UniqueNick, &user.FirstName, &user.LastName, &user.OpenHost, &user.LastIPAddress, &user.LastInGameSn)
 
 	if err != nil {

--- a/nas/main.go
+++ b/nas/main.go
@@ -173,6 +173,11 @@ func handleRequest(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if r.URL.Path == "/api/clear" {
+		api.HandleClear(w, r)
+		return
+	}
+
 	logging.Info("NAS", aurora.Yellow(r.Method), aurora.Cyan(r.URL), "via", aurora.Cyan(r.Host), "from", aurora.BrightCyan(r.RemoteAddr))
 	replyHTTPError(w, 404, "404 Not Found")
 }


### PR DESCRIPTION
Adds api command to clear a user from the database. Returns dropped user data in case the row needs to be recreated.

Removes HEAD from all routes because it was useless.