### PR TITLE
Send kick and ban reasons to players

### DIFF
--- a/api/ban.go
+++ b/api/ban.go
@@ -94,11 +94,16 @@ func handleBanImpl(w http.ResponseWriter, r *http.Request) (*database.User, bool
 		return nil, false, "Failed to ban user", http.StatusInternalServerError
 	}
 
-	if req.Tos {
-		gpcm.KickPlayer(req.Pid, "banned")
-	} else {
-		gpcm.KickPlayer(req.Pid, "restricted")
-	}
+	gpcm.KickPlayerCustomMessage(req.Pid, req.Reason, gpcm.WWFCErrorMessage{
+		ErrorCode: 22002,
+		MessageRMC: map[byte]string{
+			gpcm.LangEnglish: "" +
+				"You have been banned from Retro WFC\n" +
+				"Reason: " + req.Reason + "\n" +
+				"Error Code: %[1]d\n" +
+				"Support Info: NG%08[2]x",
+		},
+	})
 
 	var message string
 	user, success := database.GetProfile(pool, ctx, req.Pid)

--- a/database/user.go
+++ b/database/user.go
@@ -24,7 +24,7 @@ const (
 	GetUserProfileID        = `SELECT profile_id, ng_device_id, email, unique_nick, firstname, lastname, open_host FROM users WHERE user_id = $1 AND gsbrcd = $2`
 	UpdateUserLastIPAddress = `UPDATE users SET last_ip_address = $2, last_ingamesn = $3 WHERE profile_id = $1`
 	UpdateUserBan           = `UPDATE users SET has_ban = true, ban_issued = $2, ban_expires = $3, ban_reason = $4, ban_reason_hidden = $5, ban_moderator = $6, ban_tos = $7 WHERE profile_id = $1`
-	SearchUserBan           = `SELECT has_ban, ban_tos, ng_device_id FROM users WHERE has_ban = true AND (profile_id = $1 OR last_ip_address = $2) AND (ban_expires IS NULL OR ban_expires > $3) ORDER BY ban_tos DESC LIMIT 1`
+	SearchUserBan           = `SELECT has_ban, ban_tos, ng_device_id, ban_reason FROM users WHERE has_ban = true AND (profile_id = $1 OR last_ip_address = $2) AND (ban_expires IS NULL OR ban_expires > $3) ORDER BY ban_tos DESC LIMIT 1`
 	DisableUserBan          = `UPDATE users SET has_ban = false WHERE profile_id = $1`
 
 	GetMKWFriendInfoQuery    = `SELECT mariokartwii_friend_info FROM users WHERE profile_id = $1`
@@ -42,6 +42,7 @@ type User struct {
 	LastName           string
 	Restricted         bool
 	RestrictedDeviceId uint32
+	BanReason          string
 	OpenHost           bool
 	LastInGameSn       string
 	LastIPAddress      string

--- a/gpcm/kick.go
+++ b/gpcm/kick.go
@@ -49,3 +49,18 @@ func KickPlayer(profileID uint32, reason string) {
 
 	kickPlayer(profileID, reason)
 }
+
+// Exists because the above function is used in too many places to be updated easily
+func KickPlayerCustomMessage(profileID uint32, reason string, message WWFCErrorMessage) {
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	if session, exists := sessions[profileID]; exists {
+		session.replyError(GPError{
+			ErrorCode:   ErrConnectionClosed.ErrorCode,
+			ErrorString: "The player was kicked from the server. Reason: " + reason,
+			Fatal:       true,
+			WWFCMessage: message,
+		})
+	}
+}

--- a/gpcm/login.go
+++ b/gpcm/login.go
@@ -470,7 +470,16 @@ func (g *GameSpySession) performLoginWithDatabase(userId uint64, gsbrCode string
 				ErrorCode:   ErrLogin.ErrorCode,
 				ErrorString: "The profile is banned from the service.",
 				Fatal:       true,
-				WWFCMessage: WWFCMsgProfileBannedTOS,
+				WWFCMessage: WWFCErrorMessage{
+					ErrorCode: 22002,
+					MessageRMC: map[byte]string{
+						LangEnglish: "" +
+							"You are banned from Retro WFC\n" +
+							"Reason: " + user.BanReason + "\n" +
+							"Error Code: %[1]d\n" +
+							"Support Info: NG%08[2]x",
+					},
+				},
 			})
 		} else {
 			g.replyError(GPError{


### PR DESCRIPTION
See PR title. Sends reasons to players in the error message.

I sort of dislike using KickPlayerCustomMessage (see gpcm/kick.go), but I could not think of an alternative. Suggestions welcome.