### PR TITLE
Add last Mii stored to ``/pinfo``API endpoint

### DIFF
--- a/api/pinfo.go
+++ b/api/pinfo.go
@@ -34,14 +34,15 @@ func handlePinfoImpl(req PinfoRequest, validSecret bool) (*database.User, int, e
 	if !validSecret {
 		// Invalid secret, only report normal user info
 		ret = &database.User{
-			ProfileId:    realUser.ProfileId,
-			Restricted:   realUser.Restricted,
-			BanReason:    realUser.BanReason,
-			OpenHost:     realUser.OpenHost,
-			LastInGameSn: realUser.LastInGameSn,
-			BanIssued:    realUser.BanIssued,
-			BanExpires:   realUser.BanExpires,
-			DiscordID:    realUser.DiscordID,
+			ProfileId:     realUser.ProfileId,
+			Restricted:    realUser.Restricted,
+			BanReason:     realUser.BanReason,
+			OpenHost:      realUser.OpenHost,
+			LastInGameSn:  realUser.LastInGameSn,
+			BanIssued:     realUser.BanIssued,
+			BanExpires:    realUser.BanExpires,
+			DiscordID:     realUser.DiscordID,
+			LastStoredMii: realUser.LastStoredMii,
 		}
 	} else {
 		ret = &realUser

--- a/database/login.go
+++ b/database/login.go
@@ -120,7 +120,7 @@ func LoginUserToGPCM(pool *pgxpool.Pool, ctx context.Context, userId uint64, gsb
 		var lastName *string
 		var discordId *string
 
-		err := pool.QueryRow(ctx, GetUserProfileID, userId, gsbrcd).Scan(&user.ProfileId, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.OpenHost, &discordId, &lastIPAddress, &user.Csnum, &user.LastStoredMii)
+		err := pool.QueryRow(ctx, GetUserProfileID, userId, gsbrcd).Scan(&user.ProfileId, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.OpenHost, &discordId, &lastIPAddress, &user.Csnum)
 		if err != nil {
 			return User{}, err
 		}
@@ -284,7 +284,7 @@ func LoginUserToGameStats(pool *pgxpool.Pool, ctx context.Context, userId uint64
 	var lastName *string
 	var lastIPAddress *string
 	var discordId *string
-	err := pool.QueryRow(ctx, GetUserProfileID, userId, gsbrcd).Scan(&user.ProfileId, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.OpenHost, &discordId, &lastIPAddress, &user.Csnum, &user.LastStoredMii)
+	err := pool.QueryRow(ctx, GetUserProfileID, userId, gsbrcd).Scan(&user.ProfileId, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.OpenHost, &discordId, &lastIPAddress, &user.Csnum)
 	if err != nil {
 		return User{}, err
 	}

--- a/database/login.go
+++ b/database/login.go
@@ -120,7 +120,7 @@ func LoginUserToGPCM(pool *pgxpool.Pool, ctx context.Context, userId uint64, gsb
 		var lastName *string
 		var discordId *string
 
-		err := pool.QueryRow(ctx, GetUserProfileID, userId, gsbrcd).Scan(&user.ProfileId, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.OpenHost, &discordId, &lastIPAddress, &user.Csnum)
+		err := pool.QueryRow(ctx, GetUserProfileID, userId, gsbrcd).Scan(&user.ProfileId, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.OpenHost, &discordId, &lastIPAddress, &user.Csnum, &user.LastStoredMii)
 		if err != nil {
 			return User{}, err
 		}
@@ -284,7 +284,7 @@ func LoginUserToGameStats(pool *pgxpool.Pool, ctx context.Context, userId uint64
 	var lastName *string
 	var lastIPAddress *string
 	var discordId *string
-	err := pool.QueryRow(ctx, GetUserProfileID, userId, gsbrcd).Scan(&user.ProfileId, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.OpenHost, &discordId, &lastIPAddress, &user.Csnum)
+	err := pool.QueryRow(ctx, GetUserProfileID, userId, gsbrcd).Scan(&user.ProfileId, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.OpenHost, &discordId, &lastIPAddress, &user.Csnum, &user.LastStoredMii)
 	if err != nil {
 		return User{}, err
 	}

--- a/database/user.go
+++ b/database/user.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"math/rand"
+	"strings"
 	"time"
 	"wwfc/logging"
 
@@ -18,12 +19,12 @@ const (
 	UpdateUserProfileID     = `UPDATE users SET profile_id = $3 WHERE user_id = $1 AND gsbrcd = $2`
 	UpdateUserNGDeviceID    = `UPDATE users SET ng_device_id = $2 WHERE profile_id = $1`
 	UpdateUserCsnum         = `UPDATE users SET csnum = $2 WHERE profile_id = $1`
-	GetUser                 = `SELECT user_id, gsbrcd, ng_device_id, email, unique_nick, firstname, lastname, has_ban, ban_reason, open_host, last_ingamesn, last_ip_address, csnum, discord_id, ban_moderator, ban_reason_hidden, ban_issued, ban_expires, mariokartwii_friend_info FROM users WHERE profile_id = $1`
+	GetUser                 = `SELECT user_id, gsbrcd, ng_device_id, email, unique_nick, firstname, lastname, has_ban, ban_reason, open_host, last_ingamesn, last_ip_address, csnum, discord_id, ban_moderator, ban_reason_hidden, ban_issued, ban_expires FROM users WHERE profile_id = $1`
 	ClearProfileQuery       = `DELETE FROM users WHERE profile_id = $1 RETURNING user_id, gsbrcd, email, unique_nick, firstname, lastname, open_host, last_ip_address, last_ingamesn, csnum`
 	DoesUserExist           = `SELECT EXISTS(SELECT 1 FROM users WHERE user_id = $1 AND gsbrcd = $2)`
 	IsProfileIDInUse        = `SELECT EXISTS(SELECT 1 FROM users WHERE profile_id = $1)`
 	DeleteUserSession       = `DELETE FROM sessions WHERE profile_id = $1`
-	GetUserProfileID        = `SELECT profile_id, ng_device_id, email, unique_nick, firstname, lastname, open_host, discord_id, last_ip_address, csnum, mariokartwii_friend_info FROM users WHERE user_id = $1 AND gsbrcd = $2`
+	GetUserProfileID        = `SELECT profile_id, ng_device_id, email, unique_nick, firstname, lastname, open_host, discord_id, last_ip_address, csnum FROM users WHERE user_id = $1 AND gsbrcd = $2`
 	UpdateUserLastIPAddress = `UPDATE users SET last_ip_address = $2, last_ingamesn = $3 WHERE profile_id = $1`
 	UpdateDiscordID         = `UPDATE users SET discord_id = $2 WHERE profile_id = $1`
 	UpdateUserBan           = `UPDATE users SET has_ban = true, ban_issued = $2, ban_expires = $3, ban_reason = $4, ban_reason_hidden = $5, ban_moderator = $6, ban_tos = $7 WHERE profile_id = $1`
@@ -177,7 +178,7 @@ func GetProfile(pool *pgxpool.Pool, ctx context.Context, profileId uint32) (User
 	var banHiddenReason *string
 	var discordID *string
 
-	err := row.Scan(&user.UserId, &user.GsbrCode, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.Restricted, &banReason, &user.OpenHost, &lastInGameSn, &lastIPAddress, &user.Csnum, &discordID, &banModerator, &banHiddenReason, &user.BanIssued, &user.BanExpires, &user.LastStoredMii)
+	err := row.Scan(&user.UserId, &user.GsbrCode, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.Restricted, &banReason, &user.OpenHost, &lastInGameSn, &lastIPAddress, &user.Csnum, &discordID, &banModerator, &banHiddenReason, &user.BanIssued, &user.BanExpires)
 
 	if err != nil {
 		return User{}, err
@@ -216,6 +217,10 @@ func GetProfile(pool *pgxpool.Pool, ctx context.Context, profileId uint32) (User
 	if discordID != nil {
 		user.DiscordID = *discordID
 		user.LinkStage = LS_FINISHED
+	}
+
+	if strings.HasPrefix(user.GsbrCode, "RMC") {
+		user.LastStoredMii = GetMKWFriendInfo(pool, ctx, user.ProfileId)
 	}
 
 	return user, nil

--- a/database/user.go
+++ b/database/user.go
@@ -18,12 +18,12 @@ const (
 	UpdateUserProfileID     = `UPDATE users SET profile_id = $3 WHERE user_id = $1 AND gsbrcd = $2`
 	UpdateUserNGDeviceID    = `UPDATE users SET ng_device_id = $2 WHERE profile_id = $1`
 	UpdateUserCsnum         = `UPDATE users SET csnum = $2 WHERE profile_id = $1`
-	GetUser                 = `SELECT user_id, gsbrcd, ng_device_id, email, unique_nick, firstname, lastname, has_ban, ban_reason, open_host, last_ingamesn, last_ip_address, csnum, discord_id, ban_moderator, ban_reason_hidden, ban_issued, ban_expires FROM users WHERE profile_id = $1`
+	GetUser                 = `SELECT user_id, gsbrcd, ng_device_id, email, unique_nick, firstname, lastname, has_ban, ban_reason, open_host, last_ingamesn, last_ip_address, csnum, discord_id, ban_moderator, ban_reason_hidden, ban_issued, ban_expires, mariokartwii_friend_info FROM users WHERE profile_id = $1`
 	ClearProfileQuery       = `DELETE FROM users WHERE profile_id = $1 RETURNING user_id, gsbrcd, email, unique_nick, firstname, lastname, open_host, last_ip_address, last_ingamesn, csnum`
 	DoesUserExist           = `SELECT EXISTS(SELECT 1 FROM users WHERE user_id = $1 AND gsbrcd = $2)`
 	IsProfileIDInUse        = `SELECT EXISTS(SELECT 1 FROM users WHERE profile_id = $1)`
 	DeleteUserSession       = `DELETE FROM sessions WHERE profile_id = $1`
-	GetUserProfileID        = `SELECT profile_id, ng_device_id, email, unique_nick, firstname, lastname, open_host, discord_id, last_ip_address, csnum FROM users WHERE user_id = $1 AND gsbrcd = $2`
+	GetUserProfileID        = `SELECT profile_id, ng_device_id, email, unique_nick, firstname, lastname, open_host, discord_id, last_ip_address, csnum, mariokartwii_friend_info FROM users WHERE user_id = $1 AND gsbrcd = $2`
 	UpdateUserLastIPAddress = `UPDATE users SET last_ip_address = $2, last_ingamesn = $3 WHERE profile_id = $1`
 	UpdateDiscordID         = `UPDATE users SET discord_id = $2 WHERE profile_id = $1`
 	UpdateUserBan           = `UPDATE users SET has_ban = true, ban_issued = $2, ban_expires = $3, ban_reason = $4, ban_reason_hidden = $5, ban_moderator = $6, ban_tos = $7 WHERE profile_id = $1`
@@ -67,6 +67,7 @@ type User struct {
 	BanReasonHidden string
 	BanIssued       *time.Time
 	BanExpires      *time.Time
+	LastStoredMii   string
 }
 
 var (
@@ -176,7 +177,7 @@ func GetProfile(pool *pgxpool.Pool, ctx context.Context, profileId uint32) (User
 	var banHiddenReason *string
 	var discordID *string
 
-	err := row.Scan(&user.UserId, &user.GsbrCode, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.Restricted, &banReason, &user.OpenHost, &lastInGameSn, &lastIPAddress, &user.Csnum, &discordID, &banModerator, &banHiddenReason, &user.BanIssued, &user.BanExpires)
+	err := row.Scan(&user.UserId, &user.GsbrCode, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.Restricted, &banReason, &user.OpenHost, &lastInGameSn, &lastIPAddress, &user.Csnum, &discordID, &banModerator, &banHiddenReason, &user.BanIssued, &user.BanExpires, &user.LastStoredMii)
 
 	if err != nil {
 		return User{}, err


### PR DESCRIPTION
As it is, fetching Mii's from SAKE is a tedious task since it requires a GPCM token

This allows to fetch the most recent Mii from ``/api/pinfo`` itself

The Mii is sent and updated through SAKE on every WFC menu opening

The changes are fairly minor, only requesting the Mii for Mario Kart Wii users