### PR TITLE
Add server-side text wrapping for ban and kick messages

### DIFF
--- a/common/strings.go
+++ b/common/strings.go
@@ -86,3 +86,36 @@ func StringInSlice(str string, slice []string) bool {
 	}
 	return false
 }
+
+// WrapString wraps a string into multiple lines based on the maximum length.
+func WrapString(str string, maxLength int) string {
+	if maxLength <= 0 {
+		return str
+	}
+
+	runes := []rune(str)
+	var result []rune
+	currentLineLength := 0
+	lastSpaceIndex := -1
+
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		result = append(result, r)
+		if r == '\n' {
+			currentLineLength = 0
+			lastSpaceIndex = -1
+		} else {
+			currentLineLength++
+			if r == ' ' {
+				lastSpaceIndex = len(result) - 1
+			}
+			if currentLineLength > maxLength && lastSpaceIndex != -1 {
+				result[lastSpaceIndex] = '\n'
+				currentLineLength = len(result) - 1 - lastSpaceIndex
+				lastSpaceIndex = -1
+			}
+		}
+	}
+
+	return string(result)
+}

--- a/common/strings_test.go
+++ b/common/strings_test.go
@@ -1,0 +1,54 @@
+package common
+
+import (
+	"testing"
+)
+
+func TestWrapString(t *testing.T) {
+	tests := []struct {
+		name      string
+		str       string
+		maxLength int
+		expected  string
+	}{
+		{
+			name:      "simple wrap",
+			str:       "this is a long string that needs to be wrapped",
+			maxLength: 10,
+			expected:  "this is a\nlong\nstring\nthat needs\nto be\nwrapped",
+		},
+		{
+			name:      "already has newlines",
+			str:       "line 1\nline 2 with more text",
+			maxLength: 10,
+			expected:  "line 1\nline 2\nwith more\ntext",
+		},
+		{
+			name:      "no spaces",
+			str:       "thisisalongstringwithoutspaces",
+			maxLength: 10,
+			expected:  "thisisalongstringwithoutspaces",
+		},
+		{
+			name:      "exact length",
+			str:       "exactly 10",
+			maxLength: 10,
+			expected:  "exactly 10",
+		},
+		{
+			name:      "long reason",
+			str:       "Reason: Downloaded license. please use a different license or remove the friend code on this license.",
+			maxLength: 42,
+			expected:  "Reason: Downloaded license. please use a\ndifferent license or remove the friend\ncode on this license.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := WrapString(tt.str, tt.maxLength)
+			if actual != tt.expected {
+				t.Errorf("WrapString(%q, %d) = %q, expected %q", tt.str, tt.maxLength, actual, tt.expected)
+			}
+		})
+	}
+}

--- a/gpcm/error.go
+++ b/gpcm/error.go
@@ -241,6 +241,7 @@ func (err GPError) GetMessageTranslate(gameName string, region byte, lang byte, 
 
 			if errMsg != "" {
 				errMsg = fmt.Sprintf(errMsg, wwfcMessage.ErrorCode, ngid, reason)
+				errMsg = common.WrapString(errMsg, 42)
 				errMsgUTF16 := utf16.Encode([]rune(errMsg))
 				errMsgByteArray := common.UTF16ToByteArray(errMsgUTF16)
 				command.OtherValues["wl:errmsg"] = common.Base64DwcEncoding.EncodeToString(errMsgByteArray)


### PR DESCRIPTION
This PR implements server-side text wrapping for long reason strings in ban and kick messages to prevent them from appearing squished on the client. #23 

Tested locally and added unit tests