### PR TITLE
Server-Side VR implementation

### DIFF
--- a/api/main.go
+++ b/api/main.go
@@ -100,6 +100,8 @@ func StartServer(reload bool) {
 		KickRoute,
 		LinkRoute,
 		MiiRoute,
+		MKWRatingRoute,
+		MKWSeasonRoute,
 		MKWStatsRoute,
 		MotdRoute,
 		NewPlayersRoute,

--- a/api/main.go
+++ b/api/main.go
@@ -100,6 +100,7 @@ func StartServer(reload bool) {
 		KickRoute,
 		LinkRoute,
 		MiiRoute,
+		MKWStatsRoute,
 		MotdRoute,
 		NewPlayersRoute,
 		PCountRoute,

--- a/api/mkw_mmr_season.go
+++ b/api/mkw_mmr_season.go
@@ -1,0 +1,54 @@
+package api
+
+import (
+	"net/http"
+	"wwfc/database"
+)
+
+type MKWSeasonRequest struct {
+	Secret string `json:"secret"`
+	Season uint32 `json:"season"`
+}
+
+type MKWSeasonResponse struct {
+	Season    uint32
+	OldSeason uint32
+	Success   bool
+	Error     string
+}
+
+var MKWSeasonRoute = MakeRouteSpec[MKWSeasonRequest, MKWSeasonResponse](
+	false,
+	"/api/mkw_mmr_season",
+	func(req any, v bool, r *http.Request) (any, int, error) {
+		res, code, err := handleMKWMMRSeasonImpl(req.(MKWSeasonRequest), v, r)
+		if res == nil {
+			res = &MKWSeasonResponse{}
+		}
+
+		return *res, code, err
+	},
+	http.MethodGet,
+	http.MethodPost,
+)
+
+func handleMKWMMRSeasonImpl(req MKWSeasonRequest, v bool, r *http.Request) (*MKWSeasonResponse, int, error) {
+	switch r.Method {
+	case http.MethodGet:
+		return &MKWSeasonResponse{Season: database.GetGlobals().Season}, http.StatusOK, nil
+	case http.MethodPost:
+		if !v {
+			return nil, http.StatusForbidden, ErrInvalidSecret
+		}
+
+		oldSeason, err := database.GlobalSetSeason(pool, ctx, req.Season)
+
+		if err != nil {
+			return nil, http.StatusInternalServerError, err
+		}
+
+		return &MKWSeasonResponse{Season: req.Season, OldSeason: oldSeason}, http.StatusOK, nil
+	}
+
+	return nil, http.StatusMethodNotAllowed, nil
+}

--- a/api/mkw_rating.go
+++ b/api/mkw_rating.go
@@ -1,0 +1,120 @@
+package api
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+	"wwfc/database"
+	"wwfc/logging"
+)
+
+type MKWRatingRequest struct {
+	Secret    string                 `json:"secret"`
+	ProfileID uint32                 `json:"pid"`
+	Type      database.MKWRatingType `json:"rating_type"`
+	Value     uint32                 `json:"value"`
+}
+
+type MKWRatingResponse struct {
+	Rating    database.UserMKWRating
+	OldRating *database.UserMKWRating
+	Success   bool
+	Error     string
+}
+
+var MKWRatingRoute = MakeRouteSpec[MKWRatingRequest, MKWRatingResponse](
+	false,
+	"/api/mkw_rating",
+	func(req any, v bool, r *http.Request) (any, int, error) {
+		var res *MKWRatingResponse
+		var code int
+		var err error
+
+		switch r.Method {
+		case http.MethodGet:
+			res, code, err = handleGetMKWRating(r)
+		case http.MethodPost:
+			res, code, err = handleSetMKWRating(req.(MKWRatingRequest), v, r)
+		default:
+			res, code, err = &MKWRatingResponse{}, http.StatusMethodNotAllowed, nil
+		}
+
+		if res == nil {
+			res = &MKWRatingResponse{}
+		}
+
+		return *res, code, err
+	},
+	http.MethodPost,
+	http.MethodGet,
+)
+
+func handleGetMKWRating(r *http.Request) (*MKWRatingResponse, int, error) {
+	query := r.URL.Query()
+
+	pidStr := query.Get("pid")
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil {
+		return nil, http.StatusBadRequest, err
+	}
+
+	if pid == 0 {
+		return nil, http.StatusBadRequest, ErrPIDMissing
+	}
+
+	rating, err := database.GetMKWRating(pool, ctx, uint32(pid))
+	if err != nil {
+		return nil, http.StatusInternalServerError, ErrUserQuery
+	}
+
+	return &MKWRatingResponse{Rating: rating}, http.StatusOK, nil
+}
+
+var (
+	ErrInvalidRatingType      = fmt.Errorf("invalid rating type provided < %d", database.RT_LEN)
+	ErrRatingQueryTransaction = errors.New("failed to find ratings in the database, but the intended transaction may have gone through")
+)
+
+func handleSetMKWRating(req MKWRatingRequest, v bool, _ *http.Request) (*MKWRatingResponse, int, error) {
+	if !v {
+		return nil, http.StatusForbidden, ErrInvalidSecret
+	}
+
+	if req.ProfileID == 0 {
+		return nil, http.StatusBadRequest, ErrPIDMissing
+	}
+
+	if req.Type >= database.RT_LEN {
+		return nil, http.StatusBadRequest, ErrInvalidRatingType
+	}
+
+	logging.Error("GUH 1")
+	old, err := database.GetMKWRating(pool, ctx, req.ProfileID)
+	if err != nil {
+		return nil, http.StatusInternalServerError, ErrUserQuery
+	}
+	logging.Error("GUH")
+
+	err = database.UpdateMKWRating(pool, ctx, req.ProfileID, req.Type, req.Value)
+	if err != nil {
+		logging.Error("GUH", err)
+		return nil, http.StatusInternalServerError, err
+	}
+
+	newRating := old
+	switch req.Type {
+	case database.RT_VR:
+		newRating.VR = req.Value
+	case database.RT_BR:
+		newRating.BR = req.Value
+	case database.RT_MMR_RETRO_TRACKS:
+		newRating.MMR.RetroTracks = req.Value
+	case database.RT_MMR_CUSTOM_TRACKS:
+		newRating.MMR.CustomTracks = req.Value
+	case database.RT_MMR_VANILLA:
+		newRating.MMR.Vanilla = req.Value
+	}
+
+	return &MKWRatingResponse{Rating: newRating, OldRating: &old}, http.StatusOK, nil
+}

--- a/api/mkw_stats.go
+++ b/api/mkw_stats.go
@@ -1,0 +1,70 @@
+package api
+
+import (
+	"net/http"
+	"wwfc/qr2"
+)
+
+type RegionStats struct {
+	PlayerCount       int `json:"online"`
+	GroupCount        int `json:"groups"`
+	PublicPlayerCount int `json:"pub_online"`
+	PublicGroupCount  int `json:"pub_groups"`
+}
+
+type MKWStatsResponse struct {
+	AllRegions Stats                  `json:"global"`
+	ByRegion   map[string]RegionStats `json:"by_region"`
+	Success    bool
+	Error      string
+}
+
+var MKWStatsRoute = MakeRouteSpec[struct{}, MKWStatsResponse](
+	false,
+	"/api/mkw_stats",
+	func(a any, b bool, r *http.Request) (any, int, error) {
+		res, code, err := HandleMKWStats(a, b, r)
+		if res == nil {
+			res = &MKWStatsResponse{}
+		}
+
+		return *res, code, err
+	},
+	http.MethodGet,
+)
+
+func HandleMKWStats(_ any, _ bool, r *http.Request) (*MKWStatsResponse, int, error) {
+	res := MKWStatsResponse{
+		AllRegions: Stats{},
+		ByRegion:   map[string]RegionStats{},
+	}
+
+	servers := qr2.GetSessionServers()
+	groups := qr2.GetGroups([]string{"mariokartwii"}, []string{}, false)
+
+	res.AllRegions.OnlinePlayerCount = len(servers)
+	res.AllRegions.GroupCount = len(groups)
+
+	for _, group := range groups {
+		if len(group.MKWRegion) == 0 {
+			continue
+		}
+
+		regionStats, exists := res.ByRegion[group.MKWRegion]
+		if !exists {
+			regionStats = RegionStats{}
+		}
+
+		regionStats.GroupCount += 1
+		regionStats.PlayerCount += len(group.Players)
+
+		if group.MatchType == "anybody" {
+			regionStats.PublicGroupCount += 1
+			regionStats.PublicPlayerCount += len(group.Players)
+		}
+
+		res.ByRegion[group.MKWRegion] = regionStats
+	}
+
+	return &res, http.StatusOK, nil
+}

--- a/database/globals.go
+++ b/database/globals.go
@@ -1,0 +1,71 @@
+package database
+
+import (
+	"context"
+	"errors"
+	"strconv"
+
+	"github.com/jackc/pgx/v4"
+	"github.com/jackc/pgx/v4/pgxpool"
+	"github.com/linkdata/deadlock"
+)
+
+const (
+	GetMMRSeason = `SELECT val FROM globals WHERE key = 'season'`
+	SetMMRSeason = `UPDATE globals SET val = $1 WHERE key = 'season'`
+)
+
+type GlobalData struct {
+	Season uint32
+}
+
+var (
+	globals      GlobalData
+	globalsMutex = deadlock.Mutex{}
+)
+
+func GlobalsInit(pool *pgxpool.Pool, ctx context.Context) error {
+	var seasonStr string
+
+	err := pool.QueryRow(ctx, GetMMRSeason).Scan(&seasonStr)
+
+	globalsMutex.Lock()
+	defer globalsMutex.Unlock()
+
+	globals = GlobalData{}
+
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil
+		}
+
+		return err
+	}
+
+	season, err := strconv.Atoi(seasonStr)
+	if err != nil {
+		return err
+	}
+
+	globals.Season = uint32(season)
+
+	return nil
+}
+
+func GetGlobals() GlobalData {
+	globalsMutex.Lock()
+	defer globalsMutex.Unlock()
+
+	return globals
+}
+
+func GlobalSetSeason(pool *pgxpool.Pool, ctx context.Context, season uint32) (uint32, error) {
+	globalsMutex.Lock()
+	oldSeason := globals.Season
+	globals.Season = season
+	globalsMutex.Unlock()
+
+	_, err := pool.Exec(ctx, SetMMRSeason, strconv.Itoa(int(season)))
+
+	return oldSeason, err
+}

--- a/database/schema.go
+++ b/database/schema.go
@@ -23,7 +23,10 @@ func UpdateTables(pool *pgxpool.Pool, ctx context.Context) {
 		ADD IF NOT EXISTS ban_tos boolean,
 		ADD IF NOT EXISTS open_host boolean DEFAULT false,
 		ADD IF NOT EXISTS csnum character varying[],
-		ADD IF NOT EXISTS discord_id character varying;
+		ADD IF NOT EXISTS discord_id character varying,
+		ADD IF NOT EXISTS mariokartwii_vr integer DEFAULT 5000,
+		ADD IF NOT EXISTS mariokartwii_br integer DEFAULT 5000;
+
 	`)
 
 	runMigration(pool, ctx, "ng_device_id bigint", `
@@ -43,8 +46,53 @@ func UpdateTables(pool *pgxpool.Pool, ctx context.Context) {
 	ALTER TABLE ONLY public.mario_kart_wii_sake
 		ADD IF NOT EXISTS id serial PRIMARY KEY,
 		ADD IF NOT EXISTS upload_time timestamp without time zone;
-	
+
 	`)
+
+	// Create globals index. Used as an arbitrary global key-value store
+	runMigration(pool, ctx, "create public.globals", `
+
+	CREATE TABLE IF NOT EXISTS public.globals (
+		key character varying NOT NULL,
+		val character varying NOT NULL,
+		CONSTRAINT unique_key UNIQUE (key)
+	);
+
+	ALTER TABLE public.globals OWNER TO wiilink;
+
+	`)
+
+	// Create mmr table. Stores the three mmr types keyed by [profile_id, season]
+	runMigration(pool, ctx, "create public.mkw_mmr", `
+
+	CREATE TABLE IF NOT EXISTS public.mkw_mmr (
+		season integer NOT NULL,
+		profile_id bigint NOT NULL,
+		retro_tracks integer NOT NULL DEFAULT 1000,
+		custom_tracks integer NOT NULL DEFAULT 1000,
+		vanilla integer NOT NULL DEFAULT 1000,
+		CONSTRAINT unique_profile_per_season UNIQUE (season, profile_id)
+	);
+
+	ALTER TABLE public.mkw_mmr OWNER TO wiilink;
+
+	`)
+
+	runMigration(pool, ctx, "set mmr season to 1", `
+
+	INSERT INTO public.globals (key, val)
+	VALUES ('season', '1')
+	ON CONFLICT (key) DO NOTHING;
+
+	`)
+
+	// Create indexes to improve performance
+	runMigration(pool, ctx, "create public.mkw_mmr season_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS season_idx ON public.mkw_mmr (season);")
+
+	runMigration(pool, ctx, "create public.mkw_mmr profile_idx",
+		"CREATE INDEX CONCURRENTLY IF NOT EXISTS profile_idx ON public.mkw_mmr (profile_id);")
+}
 
 func runMigration(pool *pgxpool.Pool, ctx context.Context, migration string, sql string) {
 	_, err := pool.Exec(ctx, sql)

--- a/database/schema.go
+++ b/database/schema.go
@@ -2,12 +2,14 @@ package database
 
 import (
 	"context"
+	"fmt"
+	"wwfc/logging"
 
 	"github.com/jackc/pgx/v4/pgxpool"
 )
 
 func UpdateTables(pool *pgxpool.Pool, ctx context.Context) {
-	pool.Exec(ctx, `
+	runMigration(pool, ctx, "public.users", `
 
 	ALTER TABLE ONLY public.users
 		ADD IF NOT EXISTS last_ip_address character varying DEFAULT ''::character varying,
@@ -24,23 +26,34 @@ func UpdateTables(pool *pgxpool.Pool, ctx context.Context) {
 		ADD IF NOT EXISTS discord_id character varying;
 	`)
 
-	pool.Exec(ctx, `
+	runMigration(pool, ctx, "ng_device_id bigint", `
 
-	DO $$ 
+	DO $$
 	BEGIN
-    	IF (SELECT data_type FROM information_schema.columns WHERE table_name='users' AND column_name='ng_device_id') != 'ARRAY' THEN
-        	ALTER TABLE public.users
-            	ALTER COLUMN ng_device_id TYPE bigint[] using array[ng_device_id];
-    	END IF;
+		IF (SELECT data_type FROM information_schema.columns WHERE table_name='users' AND column_name='ng_device_id') != 'ARRAY' THEN
+			ALTER TABLE public.users
+				ALTER COLUMN ng_device_id TYPE bigint[] using array[ng_device_id];
+		END IF;
 	END $$;
 
 	`)
 
-	pool.Exec(ctx, `
+	runMigration(pool, ctx, "public.mario_kart_wii_sake", `
 
 	ALTER TABLE ONLY public.mario_kart_wii_sake
-        ADD IF NOT EXISTS id serial PRIMARY KEY,
+		ADD IF NOT EXISTS id serial PRIMARY KEY,
 		ADD IF NOT EXISTS upload_time timestamp without time zone;
 	
 	`)
+
+func runMigration(pool *pgxpool.Pool, ctx context.Context, migration string, sql string) {
+	_, err := pool.Exec(ctx, sql)
+	handleError(migration, err)
+}
+
+func handleError(migration string, err error) {
+	if err != nil {
+		module := fmt.Sprintf("DATABASE:%s", migration)
+		logging.Error(module, "Error applying migration:", err)
+	}
 }

--- a/database/user.go
+++ b/database/user.go
@@ -4,10 +4,13 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"math/rand"
+	"strings"
 	"time"
 	"wwfc/logging"
 
+	"github.com/jackc/pgx/v4"
 	"github.com/jackc/pgx/v4/pgxpool"
 	"github.com/logrusorgru/aurora/v3"
 )
@@ -35,6 +38,20 @@ const (
 	GetMKWFriendInfoQuery    = `SELECT mariokartwii_friend_info FROM users WHERE profile_id = $1`
 	UpdateMKWFriendInfoQuery = `UPDATE users SET mariokartwii_friend_info = $2 WHERE profile_id = $1`
 	CountTotalUsersQuery     = `SELECT COUNT(DISTINCT csnum) FROM users`
+
+	GetUserVRBR          = `SELECT mariokartwii_vr, mariokartwii_br FROM users WHERE profile_id = $1`
+	UpdateUserVRBR       = `UPDATE users SET mariokartwii_vr = $2, mariokartwii_br = $3 WHERE profile_id = $1`
+	UpdateUserVRBRSingle = `UPDATE users SET %s = $2 WHERE profile_id = $1`
+	GetUserMMR           = `SELECT
+		retro_tracks, custom_tracks, vanilla
+		FROM mkw_mmr
+		WHERE season = $1 AND profile_id = $2`
+	// fmt string to specify the mode (twice)
+	UpdateUserMMR = `INSERT
+		INTO mkw_mmr (season, profile_id, %s)
+		VALUES ($1, $2, $3)
+		ON CONFLICT (season, profile_id)
+		DO UPDATE SET %s = $3`
 )
 
 type LinkStage byte
@@ -45,6 +62,27 @@ const (
 	LS_FRIENDED
 	LS_FINISHED
 )
+
+type MKWRatingType byte
+
+const (
+	RT_VR MKWRatingType = iota
+	RT_BR
+	RT_MMR_RETRO_TRACKS
+	RT_MMR_CUSTOM_TRACKS
+	RT_MMR_VANILLA
+	RT_LEN
+)
+
+type UserMKWRating struct {
+	VR  uint32
+	BR  uint32
+	MMR struct {
+		RetroTracks  uint32
+		CustomTracks uint32
+		Vanilla      uint32
+	}
+}
 
 type User struct {
 	ProfileId          uint32
@@ -74,11 +112,14 @@ type User struct {
 }
 
 var (
-	ErrProfileIDInUse         = errors.New("profile ID is already in use")
-	ErrReservedProfileIDRange = errors.New("profile ID is in reserved range")
-	ErrFailedToGetMKWFriend   = errors.New("failed to get MKW friend info")
-	ErrCountHasNoRows         = errors.New("failed to count active users, result has no rows")
-	ErrNoLinkedProfiles       = errors.New("no profiles found with the associated discord id")
+	ErrProfileIDInUse          = errors.New("profile ID is already in use")
+	ErrReservedProfileIDRange  = errors.New("profile ID is in reserved range")
+	ErrFailedToGetMKWFriend    = errors.New("failed to get MKW friend info")
+	ErrCountHasNoRows          = errors.New("failed to count active users, result has no rows")
+	ErrNoLinkedProfiles        = errors.New("no profiles found with the associated discord id")
+	ErrInvalidMKWRatingValue   = errors.New("mkw rating is outside of the min/max bounds")
+	ErrInvalidMKWRatingType    = errors.New("invalid mkw rating type")
+	ErrInvalidMKWRatingTypeStr = errors.New("invalid mkw rating type string")
 )
 
 func (user *User) CreateUser(pool *pgxpool.Pool, ctx context.Context) error {
@@ -210,7 +251,27 @@ func GetProfile(pool *pgxpool.Pool, ctx context.Context, profileId uint32) (User
 	var banHiddenReason *string
 	var discordID *string
 
-	err := row.Scan(&user.UserId, &user.GsbrCode, &user.NgDeviceId, &user.Email, &user.UniqueNick, &firstName, &lastName, &user.Restricted, &banReason, &user.OpenHost, &lastInGameSn, &lastIPAddress, &user.Csnum, &discordID, &banModerator, &banHiddenReason, &user.BanIssued, &user.BanExpires)
+	err := row.Scan(&user.UserId,
+		&user.GsbrCode,
+		&user.NgDeviceId,
+		&user.Email,
+		&user.UniqueNick,
+		&firstName,
+		&lastName,
+		&user.Restricted,
+		&banReason,
+		&user.OpenHost,
+		&lastInGameSn,
+		&lastIPAddress,
+		&user.Csnum,
+		&discordID,
+		&banModerator,
+		&banHiddenReason,
+		&user.BanIssued,
+		&user.BanExpires,
+		// &user.VR,
+		// &user.BR,
+	)
 
 	if err != nil {
 		return User{}, err
@@ -406,4 +467,130 @@ func CountTotalUsers(pool *pgxpool.Pool, ctx context.Context) (int, error) {
 	rows.Scan(&count)
 
 	return count, nil
+}
+
+var ratingBoundsMap = map[MKWRatingType]struct {
+	max uint32
+	min uint32
+}{
+	RT_VR:                {max: 1000000, min: 0},
+	RT_BR:                {max: 1000000, min: 0},
+	RT_MMR_RETRO_TRACKS:  {max: 30000, min: 100},
+	RT_MMR_CUSTOM_TRACKS: {max: 30000, min: 100},
+	RT_MMR_VANILLA:       {max: 30000, min: 100},
+}
+
+func ValidateMKWRating(ratingType MKWRatingType, value uint32) error {
+	bounds, ok := ratingBoundsMap[ratingType]
+	if !ok {
+		return ErrInvalidMKWRatingType
+	}
+
+	if value < bounds.min || value > bounds.max {
+		return ErrInvalidMKWRatingValue
+	}
+
+	return nil
+}
+
+func ParseMKWRatingType(typeStr string) (MKWRatingType, error) {
+	switch strings.ToLower(typeStr) {
+	case "vr":
+		return RT_VR, nil
+	case "br":
+		return RT_BR, nil
+	default:
+		return 0, ErrInvalidMKWRatingTypeStr
+	}
+}
+
+func MKWRatingTypeColumn(ratingType MKWRatingType) string {
+	switch ratingType {
+	case RT_MMR_RETRO_TRACKS:
+		return "retro_tracks"
+	case RT_MMR_CUSTOM_TRACKS:
+		return "custom_tracks"
+	case RT_MMR_VANILLA:
+		return "vanilla"
+	case RT_VR:
+		return "mariokartwii_vr"
+	case RT_BR:
+		return "mariokartwii_br"
+	}
+
+	return ""
+}
+
+func GetMKWRating(pool *pgxpool.Pool, ctx context.Context, profileId uint32) (UserMKWRating, error) {
+	globals := GetGlobals()
+
+	ret := UserMKWRating{}
+
+	err := pool.QueryRow(ctx, GetUserVRBR, profileId).Scan(&ret.VR, &ret.BR)
+	if err != nil {
+		return ret, err
+	}
+
+	err = pool.QueryRow(ctx, GetUserMMR, globals.Season, profileId).Scan(&ret.MMR.RetroTracks, &ret.MMR.CustomTracks, &ret.MMR.Vanilla)
+	if errors.Is(err, pgx.ErrNoRows) {
+		ret.MMR.RetroTracks = 100
+		ret.MMR.CustomTracks = 100
+		ret.MMR.Vanilla = 100
+		return ret, nil
+	} else if err != nil {
+		logging.Error("err: ", err)
+		return ret, err
+	}
+
+	return ret, nil
+}
+
+func UpdateMKWVRBR(
+	pool *pgxpool.Pool,
+	ctx context.Context,
+	profileId uint32,
+	vr uint32,
+	br uint32,
+) error {
+	err := ValidateMKWRating(RT_VR, vr)
+	if err != nil {
+		return err
+	}
+
+	err = ValidateMKWRating(RT_BR, vr)
+	if err != nil {
+		return err
+	}
+
+	_, err = pool.Exec(ctx, UpdateUserVRBR, profileId, vr, br)
+
+	return err
+}
+
+func UpdateMKWRating(
+	pool *pgxpool.Pool,
+	ctx context.Context,
+	profileId uint32,
+	ratingType MKWRatingType,
+	value uint32,
+) error {
+	err := ValidateMKWRating(ratingType, value)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Add logging
+	globals := GetGlobals()
+	column := MKWRatingTypeColumn(ratingType)
+
+	if ratingType == RT_VR || ratingType == RT_BR {
+		query := fmt.Sprintf(UpdateUserVRBRSingle, column)
+		_, err := pool.Exec(ctx, query, profileId, value)
+		return err
+	} else {
+		query := fmt.Sprintf(UpdateUserMMR, column, column)
+		logging.Notice("GUH", query)
+		_, err := pool.Exec(ctx, query, globals.Season, profileId, value)
+		return err
+	}
 }

--- a/gpcm/report.go
+++ b/gpcm/report.go
@@ -1,8 +1,11 @@
 package gpcm
 
 import (
+	"errors"
 	"strconv"
+	"strings"
 	"wwfc/common"
+	"wwfc/database"
 	"wwfc/logging"
 	"wwfc/qr2"
 
@@ -87,6 +90,141 @@ func (g *GameSpySession) handleWWFCReport(command common.GameSpyCommand) {
 			}
 
 			qr2.ProcessMKWRaceResult(g.User.ProfileId, value)
+		case "wl:mkw_vrbr":
+			if g.GameName != "mariokartwii" {
+				logging.Warn(g.ModuleName, "Ignoring", keyColored, "from wrong game")
+				continue
+			}
+
+			vr, br, err := parseMKWVRBRRecord(value)
+			if err != nil {
+				logging.Error(g.ModuleName, "Invalid", keyColored, "record:", aurora.Cyan(value), ":", err)
+				continue
+			}
+
+			err = database.UpdateMKWVRBR(pool, ctx, g.User.ProfileId, vr, br)
+			if err != nil {
+				logging.Error(g.ModuleName,
+					"Failed to persist", keyColored, "for",
+					aurora.Cyan(g.User.ProfileId),
+					":", err,
+				)
+				continue
+			}
+
+			logging.Info(g.ModuleName,
+				"Persisted", keyColored, "for",
+				aurora.Cyan(g.User.ProfileId),
+				"vr=", vr,
+				"br=", br,
+			)
+		case "mkw_mmr":
 		}
 	}
+}
+
+var (
+	ErrMalformedEntry = errors.New("entry is malformed")
+	ErrUnknownKey     = errors.New("the provided key must be one of 'vr' or 'br'")
+	ErrMissingVR      = errors.New("record is missing vr entry")
+	ErrMissingBR      = errors.New("record is missing br entry")
+	ErrUnknownMode    = errors.New("the provided mode must be one of 'rt', 'ct', or 'vanilla'")
+	ErrMissingMode    = errors.New("record is missing mode entry")
+	ErrMissingMMR     = errors.New("record is missing mmr entry")
+)
+
+func parseMKWVRBRRecord(value string) (uint32, uint32, error) {
+	var vr uint32
+	vrMatched := false
+	var br uint32
+	brMatched := false
+
+	for split := range strings.SplitSeq(value, "|") {
+		key, raw, ok := strings.Cut(split, "=")
+		if !ok || len(key) == 0 || len(raw) == 0 {
+			return 0, 0, ErrMalformedEntry
+		}
+
+		parsed, err := strconv.Atoi(raw)
+		if err != nil {
+			return 0, 0, err
+		}
+
+		switch key {
+		case "vr":
+			vr = uint32(parsed)
+			vrMatched = true
+		case "br":
+			br = uint32(parsed)
+			brMatched = true
+		default:
+			return 0, 0, ErrUnknownKey
+		}
+	}
+
+	if !vrMatched {
+		return 0, 0, ErrMissingVR
+	}
+
+	if !brMatched {
+		return 0, 0, ErrMissingBR
+	}
+
+	return vr, br, nil
+}
+
+func parseMMRMode(mode string) (database.MKWRatingType, error) {
+	switch mode {
+	case "rt":
+		return database.RT_MMR_RETRO_TRACKS, nil
+	case "ct":
+		return database.RT_MMR_CUSTOM_TRACKS, nil
+	case "vanilla":
+		return database.RT_MMR_VANILLA, nil
+	default:
+		return 0, ErrUnknownMode
+	}
+}
+
+func parseMKWMMRRecord(value string) (database.MKWRatingType, uint32, error) {
+	var ratingType database.MKWRatingType
+	ratingTypeMatched := false
+	var mmr uint32
+	mmrMatched := false
+
+	for split := range strings.SplitSeq(value, "|") {
+		key, raw, ok := strings.Cut(split, "=")
+		if !ok || len(key) == 0 || len(raw) == 0 {
+			return 0, 0, ErrMalformedEntry
+		}
+
+		switch key {
+		case "mode":
+			parsed, err := parseMMRMode(raw)
+			if err != nil {
+				return 0, 0, err
+			}
+
+			ratingType = parsed
+			ratingTypeMatched = true
+		case "mmr":
+			parsed, err := strconv.Atoi(raw)
+			if err != nil {
+				return 0, 0, err
+			}
+
+			mmr = uint32(parsed)
+			mmrMatched = true
+		}
+	}
+
+	if !ratingTypeMatched {
+		return 0, 0, ErrMissingMode
+	}
+
+	if !mmrMatched {
+		return 0, 0, ErrMissingMMR
+	}
+
+	return ratingType, mmr, nil
 }


### PR DESCRIPTION
Full rewrite of #21.

Adds api/mkw_mmr_season and api/mkw_rating. Allows setting the mmr
season and setting the 5 player rating values respectively.

Expands database to store vr/br on players, and per-season mmr (rt, ct,
vanilla) in a separate table. Updated via gpcm reports.

This also introduces a global store for values of which only one exist
but need to be persisted in the db.